### PR TITLE
Options

### DIFF
--- a/Resources/ExifOptions.ui
+++ b/Resources/ExifOptions.ui
@@ -105,17 +105,30 @@
      </property>
     </item>
    </widget>
-   <widget class="QLabel" name="edit_caption_label">
+   <widget class="QCheckBox" name="enable_easymode_option_box">
     <property name="geometry">
      <rect>
       <x>10</x>
       <y>50</y>
-      <width>120</width>
-      <height>16</height>
+      <width>121</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="text">
-     <string>Edit Caption</string>
+     <string>EXIF Easy Mode</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="enable_easymode_oneline_box">
+    <property name="geometry">
+     <rect>
+      <x>200</x>
+      <y>50</y>
+      <width>121</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>One line</string>
     </property>
    </widget>
    <widget class="QPlainTextEdit" name="format_input_area">
@@ -147,7 +160,7 @@
     </property>
     <property name="font">
      <font>
-      <pointsize>18</pointsize>
+      <pointsize>14</pointsize>
      </font>
     </property>
     <property name="text">

--- a/Resources/ExifOptions.ui
+++ b/Resources/ExifOptions.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>461</width>
-    <height>323</height>
+    <height>333</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>280</y>
+     <y>295</y>
      <width>441</width>
      <height>32</height>
     </rect>
@@ -36,29 +36,19 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>140</y>
+     <y>100</y>
      <width>441</width>
-     <height>141</height>
+     <height>191</height>
     </rect>
    </property>
    <property name="title">
-    <string>Font Options</string>
+    <string>Caption Options</string>
    </property>
-   <widget class="QComboBox" name="font_combo_box">
-    <property name="geometry">
-     <rect>
-      <x>250</x>
-      <y>20</y>
-      <width>171</width>
-      <height>21</height>
-     </rect>
-    </property>
-   </widget>
    <widget class="QLabel" name="font_combo_box_label">
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>20</y>
+      <y>26</y>
       <width>81</width>
       <height>16</height>
      </rect>
@@ -67,38 +57,101 @@
      <string>Select Font</string>
     </property>
    </widget>
-   <widget class="QPlainTextEdit" name="font_preview_line_edit">
+   <widget class="QComboBox" name="font_combo_box">
+    <property name="geometry">
+     <rect>
+      <x>80</x>
+      <y>25</y>
+      <width>150</width>
+      <height>21</height>
+     </rect>
+    </property>
+   </widget>
+      <widget class="QLabel" name="alignment_combo_box_label">
+    <property name="geometry">
+     <rect>
+      <x>270</x>
+      <y>26</y>
+      <width>81</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Alignment</string>
+    </property>
+   </widget>
+   <widget class="QComboBox" name="alignment_combo_box">
+    <property name="geometry">
+     <rect>
+      <x>335</x>
+      <y>25</y>
+      <width>100</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <item>
+     <property name="text">
+      <string>Center</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>Left</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>Right</string>
+     </property>
+    </item>
+   </widget>
+   <widget class="QLabel" name="edit_caption_label">
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>70</y>
-      <width>411</width>
+      <y>50</y>
+      <width>120</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Edit Caption</string>
+    </property>
+   </widget>
+   <widget class="QPlainTextEdit" name="format_input_area">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>75</y>
+      <width>420</width>
       <height>51</height>
      </rect>
     </property>
     <property name="font">
      <font>
-      <pointsize>24</pointsize>
+      <pointsize>13</pointsize>
      </font>
     </property>
     <property name="frameShape">
      <enum>QFrame::NoFrame</enum>
     </property>
-    <property name="plainText">
-     <string>Canon EOS 1D X Mark III</string>
-    </property>
    </widget>
-   <widget class="QLabel" name="font_preview_label">
+   <widget class="QLabel" name="format_preview_area">
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>50</y>
-      <width>91</width>
-      <height>16</height>
+      <y>135</y>
+      <width>420</width>
+      <height>51</height>
      </rect>
     </property>
+    <property name="font">
+     <font>
+      <pointsize>18</pointsize>
+     </font>
+    </property>
     <property name="text">
-     <string>Font Preview</string>
+     <string>Loading...</string>
     </property>
    </widget>
   </widget>
@@ -108,7 +161,7 @@
      <x>10</x>
      <y>10</y>
      <width>441</width>
-     <height>121</height>
+     <height>78</height>
     </rect>
    </property>
    <property name="title">
@@ -118,61 +171,86 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>20</y>
-      <width>101</width>
-      <height>16</height>
+      <y>25</y>
+      <width>121</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="text">
      <string>Padding</string>
     </property>
    </widget>
-   <widget class="QCheckBox" name="enable_square_mode_box">
+   <widget class="QCheckBox" name="save_exif_data_box">
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>80</y>
-      <width>111</width>
-      <height>16</height>
+      <y>50</y>
+      <width>121</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="text">
-     <string>Square Mode</string>
+     <string>Save Exif Data</string>
     </property>
    </widget>
-   <widget class="QCheckBox" name="enable_dark_mode_box">
+   <widget class="QLabel" name="image_ratio_label">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>40</y>
-      <width>91</width>
-      <height>16</height>
+      <x>140</x>
+      <y>20</y>
+      <width>50</width>
+      <height>25</height>
      </rect>
     </property>
     <property name="text">
-     <string>White Text</string>
+     <string>Ratio</string>
     </property>
    </widget>
-   <widget class="QCheckBox" name="enable_one_line_box">
+   <widget class="QComboBox" name="image_ratio_box">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>60</y>
+      <x>170</x>
+      <y>22</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <item>
+     <property name="text">
+      <string>Original</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>Square</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>4:5</string>
+     </property>
+    </item>
+   </widget>
+   <widget class="QLabel" name="image_format_label">
+    <property name="geometry">
+     <rect>
+      <x>275</x>
+      <y>20</y>
       <width>120</width>
-      <height>16</height>
+      <height>25</height>
      </rect>
     </property>
     <property name="text">
-     <string>1 line text</string>
+     <string>Image Type</string>
     </property>
    </widget>
-   <widget class="QComboBox" name="save_format_box">
+   <widget class="QComboBox" name="image_type_box">
     <property name="geometry">
      <rect>
       <x>345</x>
-      <y>19</y>
-      <width>76</width>
-      <height>31</height>
+      <y>22</y>
+      <width>90</width>
+      <height>25</height>
      </rect>
     </property>
     <item>
@@ -191,43 +269,62 @@
      </property>
     </item>
    </widget>
-   <widget class="QPushButton" name="open_color_picker_button">
+   <widget class="QSpinBox" name="image_quality_spinbox">
     <property name="geometry">
      <rect>
-      <x>320</x>
-      <y>60</y>
-      <width>101</width>
-      <height>31</height>
+      <x>190</x>
+      <y>49</y>
+      <width>60</width>
+      <height>24</height>
      </rect>
     </property>
-    <property name="text">
-     <string>ColorPicker</string>
+    <property name="minimum">
+     <number>1</number>
+    </property>
+    <property name="maximum">
+     <number>100</number>
+    </property>
+    <property name="value">
+     <number>80</number>
     </property>
    </widget>
-   <widget class="QCheckBox" name="save_exif_data_box">
+   <widget class="QLabel" name="image_quality_label">
     <property name="geometry">
      <rect>
-      <x>110</x>
-      <y>20</y>
-      <width>121</width>
-      <height>20</height>
+      <x>140</x>
+      <y>49</y>
+      <width>44</width>
+      <height>24</height>
      </rect>
     </property>
     <property name="text">
-     <string>Save Exif Data</string>
+     <string>Quality</string>
     </property>
    </widget>
-   <widget class="QLabel" name="save_format_label">
+   <widget class="QPushButton" name="open_text_color_button">
     <property name="geometry">
      <rect>
-      <x>280</x>
-      <y>20</y>
-      <width>56</width>
-      <height>16</height>
+      <x>265</x>
+      <y>46</y>
+      <width>80</width>
+      <height>32</height>
      </rect>
     </property>
     <property name="text">
-     <string>Format</string>
+     <string>Text Color</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="open_bg_color_button">
+    <property name="geometry">
+     <rect>
+      <x>350</x>
+      <y>46</y>
+      <width>80</width>
+      <height>32</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>BG Color</string>
     </property>
    </widget>
   </widget>

--- a/Resources/ResizeOption.ui
+++ b/Resources/ResizeOption.ui
@@ -66,6 +66,26 @@
       <height>22</height>
      </rect>
     </property>
+    <item>
+     <property name="text">
+      <string>Width</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>Height</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>Longest</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>Shortest</string>
+     </property>
+    </item>
     <stringlist>
      <string>Width</string>
      <string>Height</string>

--- a/Resources/ResizeOption.ui
+++ b/Resources/ResizeOption.ui
@@ -44,42 +44,42 @@
    <property name="title">
     <string>Resize Options</string>
    </property>
-   <widget class="QCheckBox" name="width_option_box">
+   <widget class="QLabel" name="axis_option_label">
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>20</y>
-      <width>81</width>
-      <height>16</height>
+      <y>38</y>
+      <width>56</width>
+      <height>22</height>
      </rect>
     </property>
     <property name="text">
-     <string>Width</string>
-    </property>
-    <property name="checked">
-     <bool>true</bool>
+     <string>Axis</string>
     </property>
    </widget>
-   <widget class="QCheckBox" name="height_option_box">
+   <widget class="QComboBox" name="axis_option_box">
     <property name="geometry">
      <rect>
-      <x>130</x>
-      <y>20</y>
-      <width>81</width>
-      <height>16</height>
+      <x>80</x>
+      <y>38</y>
+      <width>131</width>
+      <height>22</height>
      </rect>
     </property>
-    <property name="text">
+    <stringlist>
+     <string>Width</string>
      <string>Height</string>
-    </property>
+     <string>Longest</string>
+     <string>Shortest</string>
+    </stringlist>
    </widget>
    <widget class="QLabel" name="resize_value_label">
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>52</y>
+      <y>82</y>
       <width>56</width>
-      <height>20</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="text">
@@ -89,9 +89,9 @@
    <widget class="QSpinBox" name="resize_value_box">
     <property name="geometry">
      <rect>
-      <x>130</x>
-      <y>50</y>
-      <width>81</width>
+      <x>80</x>
+      <y>82</y>
+      <width>131</width>
       <height>22</height>
      </rect>
     </property>

--- a/Resources/WebPConverterGUI.ui
+++ b/Resources/WebPConverterGUI.ui
@@ -278,7 +278,7 @@
      <enum>Qt::NoFocus</enum>
     </property>
     <property name="text">
-     <string>Preview</string>
+     <string>Preview(X)</string>
     </property>
    </widget>
    <widget class="QGroupBox" name="resize_option_group_box">

--- a/Resources/WebPConverterGUI.ui
+++ b/Resources/WebPConverterGUI.ui
@@ -175,7 +175,7 @@
       </rect>
      </property>
      <property name="text">
-      <string>Options</string>
+      <string>TBD</string>
      </property>
     </widget>
    </widget>

--- a/app_window/webp_window.py
+++ b/app_window/webp_window.py
@@ -85,7 +85,8 @@ class WebpWindow(QMainWindow, formClass):
         # 실행 버튼 함수 링킹
         self.add_button.clicked.connect(self.open_file)
         self.add_button.setToolTip("파일 선택하기")
-        #self.delete_button.clicked.connect(None)
+        self.delete_button.clicked.connect(self.delete_file)
+        self.delete_button.setToolTip("선택된 파일 삭제하기")
         self.save_button.clicked.connect(self.on_click_save)
         self.save_button.setToolTip("파일 저장하기")
         # 파일 추가 기능 함수 링킹
@@ -200,6 +201,13 @@ class WebpWindow(QMainWindow, formClass):
         pass #self.watermark_option_window.on_call()
 
     def on_click_exif_padding_option(self):
+        selected_item_index = self.image_list_widget.currentRow()
+        if selected_item_index < 0 or selected_item_index >= self.image_list_widget.count():
+            self.exif_padding_option_window.selected_exif_data = None
+        else:
+            file_path = self.image_list_widget.currentItem().text()
+            self.exif_padding_option_window.selected_exif_data = self.converter.get_exif_data_on_path(file_path)
+
         self.exif_padding_option_window.on_call()
     
     def on_trigger_add_files(self):
@@ -212,6 +220,7 @@ class WebpWindow(QMainWindow, formClass):
 
     def on_trigger_clear_files(self):
         self.image_list_widget.clear()
+        self.file_name.clear()
 
     def on_trigger_information(self):
         self.information_window.show()
@@ -226,6 +235,8 @@ class WebpWindow(QMainWindow, formClass):
         if len(open_files) > 0:
             load_path = None
 
+            # select first item of added lists
+            latest_index = self.image_list_widget.count()
             for file in open_files[0]:
                 if "" == file: continue
                 if "All Files (*)" == file: continue
@@ -234,10 +245,25 @@ class WebpWindow(QMainWindow, formClass):
                     load_path = os.path.dirname(file)
 
                 self.load_file(file)
+            self.image_list_widget.setCurrentItem(self.image_list_widget.item(latest_index))
             
             if load_path:
                 UserConfig.latest_load_path = load_path
                 UserConfig.save()
+
+    def delete_file(self):
+        selected_index = self.image_list_widget.currentRow()
+        if selected_index < 0 or selected_index >= self.image_list_widget.count():
+            return
+        
+        # Remove the selected item from the list
+        deleted_item = self.image_list_widget.takeItem(selected_index)
+        deleted_text = deleted_item.text()
+        deleted_file_name = self.file_name.pop(selected_index)
+        print(f"Deleted item at index {selected_index}: {deleted_text} ({deleted_file_name})")
+
+        
+    
 
     def load_file(self, filePath):
         icon = QtGui.QIcon(filePath)

--- a/app_window/webp_window.py
+++ b/app_window/webp_window.py
@@ -174,7 +174,9 @@ class WebpWindow(QMainWindow, formClass):
                                                     ratio_option=UserConfig.exif_ratio,
                                                     exif_padding_option=UserConfig.exif_padding,
                                                     alignment_option=UserConfig.exif_format_alignment,
-                                                    caption_format=UserConfig.exif_format)
+                                                    caption_format=UserConfig.exif_format,
+                                                    easymode_option=UserConfig.exif_easymode_options,
+                                                    easymode_oneline=UserConfig.exif_easymode_oneline)
 
     def on_click_open_resize_option(self):
         def on_accepted_resize_option(axis_option, resize_value):
@@ -294,7 +296,9 @@ class WebpWindow(QMainWindow, formClass):
                                                       alignment_option=UserConfig.exif_format_alignment,
                                                       resize_value=UserConfig.resize_size,
                                                       quality_option=UserConfig.exif_quality,
-                                                      caption_format=UserConfig.exif_format)
+                                                      caption_format=UserConfig.exif_format,
+                                                      easymode_option=UserConfig.exif_easymode_options,
+                                                      easymode_oneline=UserConfig.exif_easymode_oneline)
 
             else:
                 print("옵션 선택 에러 / 다시 선택해주세요")

--- a/app_window/webp_window.py
+++ b/app_window/webp_window.py
@@ -97,8 +97,7 @@ class WebpWindow(QMainWindow, formClass):
 
         # Resize 관련 변수 초기화
         self.resize_option = False
-        self.resize_width_option = self.resize_window.width_option
-        self.resize_height_option = self.resize_window.height_option
+        self.resize_axis_option = self.resize_window.axis_option
         self.resize_value = self.resize_window.resize_value
 
         self.setupUi(self)
@@ -125,7 +124,6 @@ class WebpWindow(QMainWindow, formClass):
         self.actionExit.triggered.connect(WebpWindow.on_trigger_exit)
         # Conversion 활성화 옵션 링킹
         self.enable_conversion_option_box.stateChanged.connect(self.on_toggle_conversion_enable)
-        self.enable_conversion_option_box.toggle()
         self.open_conversion_option_button.clicked.connect(self.on_click_conversion_option)
         self.open_conversion_option_button.setEnabled(self.enable_conversion_option_box.isChecked())
         # Watermark 활성화 옵션 링킹
@@ -154,6 +152,15 @@ class WebpWindow(QMainWindow, formClass):
         UserConfig.load()
         if UserConfig.exif_bg_color:
             self.background_color = UserConfig.exif_bg_color
+
+        if UserConfig.resize_options:
+            self.enable_resize_option_box.toggle()
+
+        if UserConfig.conversion_options:
+            self.enable_conversion_option_box.toggle()
+
+        if UserConfig.exif_options:
+            self.enable_exif_padding_option_box.toggle()
 
     def resizeEvent(self, event):
         geometry = self.image_list_widget.geometry()
@@ -195,14 +202,13 @@ class WebpWindow(QMainWindow, formClass):
                                     one_line_option=self.line_text_option)
 
     def on_click_open_resize_option(self):
-        def on_accepted_resize_option(width_option, height_option, resize_value):
+        def on_accepted_resize_option(axis_option, resize_value):
             # note(komastar) : 리사이즈 정보 쿼리 방법 1. callback
             # accept 된 경우에만 실행
-            self.resize_width_option = width_option
-            self.resize_height_option = height_option
+            self.resize_axis_option = axis_option
             self.resize_value = resize_value
 
-            print(f'width : {width_option}, height : {height_option}, resize value: {resize_value}')
+            print(f'Axis(0:Width,1:Height,2:Longest,3:Shortest) : {axis_option}, resize value: {resize_value}')
 
         self.resize_window.on_accepted = on_accepted_resize_option
         self.resize_window.show()
@@ -335,8 +341,7 @@ class WebpWindow(QMainWindow, formClass):
                                                          exif_view_option=self.exif_writing_option,
                                                          conversion_option=self.conversion_option,
                                                          resize_option=self.resize_option,
-                                                         width_option=self.resize_width_option,
-                                                         height_option=self.resize_height_option,
+                                                         axis_option=self.resize_axis_option,
                                                          resize_value=self.resize_value)
 
             # 02 Exif Padding 이미지로만 변환할때
@@ -354,8 +359,7 @@ class WebpWindow(QMainWindow, formClass):
                                                       one_line_option=self.line_text_option,
                                                       save_exif_data_option=self.save_exif_data,
                                                       resize_option=self.resize_option,
-                                                      width_option=self.resize_width_option,
-                                                      height_option=self.resize_height_option,
+                                                      axis_option=self.resize_axis_option,
                                                       resize_value=self.resize_value)
 
             else:
@@ -373,7 +377,11 @@ class WebpWindow(QMainWindow, formClass):
     def on_toggle_conversion_enable(self, state):
         self.conversion_option = bool(state == Qt.CheckState.Checked.value)
         self.enable_exif_padding_option_box.setChecked(not state)
-        self.open_conversion_option_button.setEnabled(self.enable_conversion_option_box.isChecked())
+
+        checked = self.enable_conversion_option_box.isChecked()
+        self.open_conversion_option_button.setEnabled(checked)
+        UserConfig.conversion_options = checked
+        UserConfig.save()
 
     # 워터마크 옵션
     def WatermarkColorOption(self, state):
@@ -383,10 +391,18 @@ class WebpWindow(QMainWindow, formClass):
     def on_toggle_exif_writing_enable(self, state):
         self.exif_writing_option = bool(state == Qt.CheckState.Checked.value)
         self.enable_conversion_option_box.setChecked(not state)
-        self.open_exif_option_button.setEnabled(self.enable_exif_padding_option_box.isChecked())
-        self.preview_button.setEnabled(self.enable_exif_padding_option_box.isChecked())
+
+        checked = self.enable_exif_padding_option_box.isChecked()
+        self.open_exif_option_button.setEnabled(checked)
+        self.preview_button.setEnabled(checked)
+        UserConfig.exif_options = checked
+        UserConfig.save()
 
     def on_toggle_resize_enable(self, state):
         self.resize_option = bool(state == Qt.CheckState.Checked.value)
-        self.open_resize_option_button.setEnabled(self.enable_resize_option_box.isChecked())
+        checked = self.enable_resize_option_box.isChecked()
+        self.open_resize_option_button.setEnabled(checked)
+
+        UserConfig.resize_options = checked
+        UserConfig.save()
 

--- a/app_window/webp_window.py
+++ b/app_window/webp_window.py
@@ -128,6 +128,7 @@ class WebpWindow(QMainWindow, formClass):
         self.open_conversion_option_button.setEnabled(self.enable_conversion_option_box.isChecked())
         # Watermark 활성화 옵션 링킹
         #self.enable_watermark_option_box.stateChanged.connect(None)
+        self.enable_watermark_option_box.setEnabled(False)
         # Exif Padding 활성화 옵션 링킹
         self.enable_exif_padding_option_box.stateChanged.connect(self.on_toggle_exif_writing_enable)
         self.open_exif_option_button.clicked.connect(self.on_click_exif_padding_option)

--- a/app_window/webp_window.py
+++ b/app_window/webp_window.py
@@ -211,7 +211,7 @@ class WebpWindow(QMainWindow, formClass):
             print(f'Axis(0:Width,1:Height,2:Longest,3:Shortest) : {axis_option}, resize value: {resize_value}')
 
         self.resize_window.on_accepted = on_accepted_resize_option
-        self.resize_window.show()
+        self.resize_window.on_call()
         # note(komastar) : 리사이즈 정보 쿼리 방법 2. access public property
         # accept 되기 전에 호출하면 제대로 된 값을 불러오지 못 할 수 있음
         # print(f'w:{self.resize_option_window.width}, h:{self.resize_option_window.height}')

--- a/app_window/webp_window.py
+++ b/app_window/webp_window.py
@@ -79,27 +79,6 @@ class WebpWindow(QMainWindow, formClass):
         # 파일 이름 변수
         self.file_name = []
 
-        # Conversion 관련 Flag 변수 초기화
-        self.loseless_option = self.webp_conversion_option_window.loseless_option
-        self.exif_option = self.webp_conversion_option_window.exif_option
-        self.icc_profile_option = self.webp_conversion_option_window.icc_profile_option
-        self.exact_option = self.webp_conversion_option_window.exact_option
-        self.image_quality_option = self.webp_conversion_option_window.image_quality_option
-
-        self.padding_option = self.exif_padding_option_window.enable_padding
-        self.square_mode_option = False# self.exif_padding_option_window.enable_square_mode
-        self.dark_mode_option = False# self.exif_padding_option_window.enable_dark_mode
-        self.line_text_option = False#self.exif_padding_option_window.enable_one_line
-        self.save_exif_data = self.exif_padding_option_window.save_exif
-        self.save_format_index = 0#self.exif_padding_option_window.save_format_index
-        self.selected_font = self.exif_padding_option_window.selected_font
-        self.background_color = self.exif_padding_option_window.background_color
-
-        # Resize 관련 변수 초기화
-        self.resize_option = False
-        self.resize_axis_option = self.resize_window.axis_option
-        self.resize_value = self.resize_window.resize_value
-
         self.setupUi(self)
         self.bind_ui()
         self.init_options()
@@ -119,7 +98,8 @@ class WebpWindow(QMainWindow, formClass):
         self.actionInformation.triggered.connect(self.on_trigger_information)
         # Exif Frame Preview 표시 기능 링킹
         self.preview_button.clicked.connect(self.on_click_preview)
-        self.preview_button.setEnabled(self.enable_exif_padding_option_box.isChecked())
+        #self.preview_button.setEnabled(self.enable_exif_padding_option_box.isChecked())
+        self.preview_button.setEnabled(False) # temporarily disabled
         # 종료 버튼 함수 링킹
         self.actionExit.triggered.connect(WebpWindow.on_trigger_exit)
         # Conversion 활성화 옵션 링킹
@@ -151,9 +131,6 @@ class WebpWindow(QMainWindow, formClass):
         self.resize_option = self.enable_resize_option_box.isChecked()
 
         UserConfig.load()
-        if UserConfig.exif_bg_color:
-            self.background_color = UserConfig.exif_bg_color
-
         if UserConfig.resize_options:
             self.enable_resize_option_box.toggle()
 
@@ -191,16 +168,15 @@ class WebpWindow(QMainWindow, formClass):
             self.save_file()
 
     def on_click_preview(self):
-        self.update_options()
-        
         self.converter.show_sample_exif_frame_image(file_path=sample_file_path,
-                                    file_name="Sample.jpg",
-                                    font_path=self.selected_font,
-                                    bg_color=self.background_color,
-                                    square_padding_option=self.square_mode_option,
-                                    dark_theme_option=self.dark_mode_option,
-                                    exif_padding_option=self.padding_option,
-                                    one_line_option=self.line_text_option)
+                                                    file_name="Sample.jpg",
+                                                    font_path=self.exif_padding_option_window.get_current_font_path(),
+                                                    text_color=UserConfig.exif_text_color,
+                                                    bg_color=UserConfig.exif_bg_color,
+                                                    ratio_option=UserConfig.exif_ratio,
+                                                    exif_padding_option=UserConfig.exif_padding,
+                                                    alignment_option=UserConfig.exif_format_alignment,
+                                                    caption_format=UserConfig.exif_format)
 
     def on_click_open_resize_option(self):
         def on_accepted_resize_option(axis_option, resize_value):
@@ -263,46 +239,6 @@ class WebpWindow(QMainWindow, formClass):
                 UserConfig.latest_load_path = load_path
                 UserConfig.save()
 
-    #################### FUNCTIONS
-    def update_options(self):
-        # note(CANU): on_call() 로 호출 후 convert ui close 시 데이터 업데이트가 안되는 문제
-        # 다시 click을 호출해야 데이터가 업데이트되는 관계로, 창을 close 시 호출되는 함수를 찾아봐야겠음
-
-        # save 버튼 클릭 후 호출할 때 option을 마지막으로 업데이트하는 형식으로 변경
-        # 어짜피 마지막 선택한 옵션만 필요한거 아닐까?
-        
-        if self.conversion_option:
-            self.loseless_option = self.webp_conversion_option_window.loseless_option
-            self.exif_option = self.webp_conversion_option_window.exif_option
-            self.icc_profile_option = self.webp_conversion_option_window.icc_profile_option
-            self.exact_option = self.webp_conversion_option_window.exact_option
-            self.image_quality_option = self.webp_conversion_option_window.image_quality_option
-                
-            print(f"Loseless Option (main): {self.loseless_option}")
-            print(f"Exif Option (main): {self.exif_option}")
-            print(f"Icc Profile Option (main): {self.icc_profile_option}")
-            print(f"Transparent RGB Option (main): {self.exact_option}")
-            print(f"Image Quality (main): {self.image_quality_option}")
-
-        elif self.exif_writing_option:
-            self.padding_option = self.exif_padding_option_window.enable_padding
-            self.square_mode_option = False# self.exif_padding_option_window.enable_square_mode
-            self.dark_mode_option = False#self.exif_padding_option_window.enable_dark_mode
-            self.line_text_option = False#self.exif_padding_option_window.enable_one_line
-            self.save_exif_data = self.exif_padding_option_window.save_exif
-            self.save_format_index = self.exif_padding_option_window.save_format_index
-            self.selected_font = self.exif_padding_option_window.selected_font
-            self.background_color = self.exif_padding_option_window.background_color
-
-            print(f"Frame Option (main): {self.padding_option}")
-            print(f"1:1 Option (main): {self.square_mode_option}")
-            print(f"White Text Option (main): {self.dark_mode_option}")
-            print(f"One line Option (main): {self.line_text_option}")
-            print(f"Save Exif Option (main): {self.save_exif_data}")
-            print(f"Save Format (main): {self.save_format_index}")
-            print(f"Selected Font (main): {self.selected_font}")
-            print(f"Background Color (main): {self.background_color}")
-
     def load_file(self, filePath):
         icon = QtGui.QIcon(filePath)
         item = QtWidgets.QListWidgetItem(icon, filePath)
@@ -325,8 +261,6 @@ class WebpWindow(QMainWindow, formClass):
         UserConfig.latest_save_path = save_path
         UserConfig.save()
 
-        self.update_options()
-
         if save_path:
             # 01 WebP 이미지로만 변환할 때
             if self.conversion_option:
@@ -334,16 +268,15 @@ class WebpWindow(QMainWindow, formClass):
                     self.converter.convert_image_to_webp(file_path=self.image_list_widget.item(index).text(),
                                                          save_path=save_path + '/',
                                                          save_name=self.file_name[index],
-                                                         loseless_option=self.loseless_option,
-                                                         image_quality_option=self.image_quality_option,
-                                                         exif_option=self.exif_option,
-                                                         icc_profile_option=self.icc_profile_option,
-                                                         exact_option=self.exact_option, watermark_text="",
-                                                         exif_view_option=self.exif_writing_option,
+                                                         loseless_option=UserConfig.conversion_loseless,
+                                                         image_quality_option=UserConfig.conversion_quality,
+                                                         exif_option=UserConfig.conversion_exif,
+                                                         icc_profile_option=UserConfig.conversion_icc,
+                                                         exact_option=UserConfig.conversion_transparent, watermark_text="",
                                                          conversion_option=self.conversion_option,
                                                          resize_option=self.resize_option,
-                                                         axis_option=self.resize_axis_option,
-                                                         resize_value=self.resize_value)
+                                                         axis_option=UserConfig.resize_options,
+                                                         resize_value=UserConfig.resize_size)
 
             # 02 Exif Padding 이미지로만 변환할때
             elif self.exif_writing_option:
@@ -351,17 +284,19 @@ class WebpWindow(QMainWindow, formClass):
                     self.converter.convert_exif_image(file_path=self.image_list_widget.item(index).text(),
                                                       save_path=save_path + '/',
                                                       save_name=self.file_name[index],
-                                                      file_format_option=self.save_format_index,
-                                                      font_path=self.selected_font,
-                                                      bg_color=self.background_color,
-                                                      square_padding_option=self.square_mode_option,
-                                                      dark_theme_option=self.dark_mode_option,
-                                                      exif_padding_option=self.padding_option,
-                                                      one_line_option=self.line_text_option,
-                                                      save_exif_data_option=self.save_exif_data,
+                                                      file_format_option=UserConfig.exif_type,
+                                                      font_path=self.exif_padding_option_window.get_current_font_path(),
+                                                      bg_color=UserConfig.exif_bg_color,
+                                                      text_color=UserConfig.exif_text_color,
+                                                      ratio_option=UserConfig.exif_ratio,
+                                                      exif_padding_option=UserConfig.exif_padding,
+                                                      save_exif_data_option=UserConfig.exif_save_exifdata,
                                                       resize_option=self.resize_option,
-                                                      axis_option=self.resize_axis_option,
-                                                      resize_value=self.resize_value)
+                                                      axis_option=UserConfig.resize_axis,
+                                                      alignment_option=UserConfig.exif_format_alignment,
+                                                      resize_value=UserConfig.resize_size,
+                                                      quality_option=UserConfig.exif_quality,
+                                                      caption_format=UserConfig.exif_format)
 
             else:
                 print("옵션 선택 에러 / 다시 선택해주세요")
@@ -395,7 +330,7 @@ class WebpWindow(QMainWindow, formClass):
 
         checked = self.enable_exif_padding_option_box.isChecked()
         self.open_exif_option_button.setEnabled(checked)
-        self.preview_button.setEnabled(checked)
+        #self.preview_button.setEnabled(checked)
         UserConfig.exif_options = checked
         UserConfig.save()
 

--- a/app_window/webp_window.py
+++ b/app_window/webp_window.py
@@ -152,8 +152,8 @@ class WebpWindow(QMainWindow, formClass):
         self.resize_option = self.enable_resize_option_box.isChecked()
 
         UserConfig.load()
-        if UserConfig.background_color:
-            self.background_color = UserConfig.background_color
+        if UserConfig.exif_bg_color:
+            self.background_color = UserConfig.exif_bg_color
 
     def resizeEvent(self, event):
         geometry = self.image_list_widget.geometry()
@@ -238,13 +238,23 @@ class WebpWindow(QMainWindow, formClass):
         sys.exit()
 
     def open_file(self):
-        open_files = QFileDialog.getOpenFileNames(self, "Open File")
+        open_files = QFileDialog.getOpenFileNames(self, caption="Open File", directory=UserConfig.latest_load_path)
 
         if len(open_files) > 0:
+            load_path = None
+
             for file in open_files[0]:
                 if "" == file: continue
                 if "All Files (*)" == file: continue
+
+                if not load_path:
+                    load_path = os.path.dirname(file)
+
                 self.load_file(file)
+            
+            if load_path:
+                UserConfig.latest_load_path = load_path
+                UserConfig.save()
 
     #################### FUNCTIONS
     def update_options(self):

--- a/app_window/webp_window.py
+++ b/app_window/webp_window.py
@@ -12,8 +12,6 @@ import webp
 from PyQt6.QtWidgets import *
 from PyQt6 import uic
 from PyQt6 import QtGui, QtWidgets, QtCore
-from PyQt6.QtGui import QPalette, QColor, QFont
-from PyQt6.QtGui import QFontDatabase
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QMainWindow, QFileDialog, QColorDialog, QPushButton, QPlainTextEdit
 print("PyQt6 Package Loaded")

--- a/app_window/webp_window.py
+++ b/app_window/webp_window.py
@@ -87,11 +87,11 @@ class WebpWindow(QMainWindow, formClass):
         self.image_quality_option = self.webp_conversion_option_window.image_quality_option
 
         self.padding_option = self.exif_padding_option_window.enable_padding
-        self.square_mode_option = self.exif_padding_option_window.enable_square_mode
-        self.dark_mode_option = self.exif_padding_option_window.enable_dark_mode
-        self.line_text_option = self.exif_padding_option_window.enable_one_line
+        self.square_mode_option = False# self.exif_padding_option_window.enable_square_mode
+        self.dark_mode_option = False# self.exif_padding_option_window.enable_dark_mode
+        self.line_text_option = False#self.exif_padding_option_window.enable_one_line
         self.save_exif_data = self.exif_padding_option_window.save_exif
-        self.save_format_index = self.exif_padding_option_window.save_format_index
+        self.save_format_index = 0#self.exif_padding_option_window.save_format_index
         self.selected_font = self.exif_padding_option_window.selected_font
         self.background_color = self.exif_padding_option_window.background_color
 
@@ -286,9 +286,9 @@ class WebpWindow(QMainWindow, formClass):
 
         elif self.exif_writing_option:
             self.padding_option = self.exif_padding_option_window.enable_padding
-            self.square_mode_option = self.exif_padding_option_window.enable_square_mode
-            self.dark_mode_option = self.exif_padding_option_window.enable_dark_mode
-            self.line_text_option = self.exif_padding_option_window.enable_one_line
+            self.square_mode_option = False# self.exif_padding_option_window.enable_square_mode
+            self.dark_mode_option = False#self.exif_padding_option_window.enable_dark_mode
+            self.line_text_option = False#self.exif_padding_option_window.enable_one_line
             self.save_exif_data = self.exif_padding_option_window.save_exif
             self.save_format_index = self.exif_padding_option_window.save_format_index
             self.selected_font = self.exif_padding_option_window.selected_font

--- a/caption_format_converter.py
+++ b/caption_format_converter.py
@@ -1,0 +1,139 @@
+from PIL import Image, ImageDraw, ImageFont
+from PIL.ExifTags import TAGS
+from model_name_mapper import ModelNameMapper
+
+class CaptionFormatConverter():
+    dump_data = "NONEDATA"
+
+    exif_dic = {
+        "{body}": (272, "Camera Name"),
+        "{lens}": (42036, "Lens Name 12-345mm f/6.7"),
+        "{focal_f}": (41989, 51),
+        "{aper}": (33437, 5.6),
+        "{iso}": (34855, 100),
+        "{ss}": (33434, 0.01),
+        "{mf}": (271, "Camera Maker"),
+        "{mf_l}": (42035, "Lens Maker"),
+        "{focal}": (37386, 34),
+        "{ev}": (37380, 1.33),
+        "{meter}": (32383, 1),
+        "{mode}": (34850, 3),
+        "{time}": (36867, "1972:11:21 16:16:16"),
+        "{cr}": (33432, "Copyrigth (C) Text here"),
+        "{ar}": (315, "Artist Name"),
+    }
+
+    @staticmethod
+    def convert(text:str, exif_data=None) -> str:
+        exif_actual_dic = {}
+
+        try:
+            for key in list(CaptionFormatConverter.exif_dic.keys()):
+                if key in exif_actual_dic: continue
+                if key in text:
+                    exif_actual_dic[key] = CaptionFormatConverter.get_value_in_key(key, exif_data)
+
+            text_replaced = text
+            for key in list(exif_actual_dic.keys()):
+                value = exif_actual_dic[key]
+                if value and value != CaptionFormatConverter.dump_data:
+                    text_replaced = text_replaced.replace(key, value)
+        except Exception as e:
+            print(e)
+            print("데이터 불량, 콘솔 창의 기록을 댓글로 남겨주세요.")
+            text_replaced = text
+
+        return text_replaced
+    
+    @staticmethod
+    def get_value_in_key(key, exif_data) -> str:
+        if key not in CaptionFormatConverter.exif_dic:
+            return CaptionFormatConverter.dump_data
+
+        values = CaptionFormatConverter.exif_dic[key]
+        value = exif_data.get(values[0], CaptionFormatConverter.dump_data) if exif_data else values[1]
+        if value == CaptionFormatConverter.dump_data:
+            if exif_data:
+                print("[" + key + "]: value not found")
+            return value
+
+        result = str(value)
+        if key == "{body}": result = CaptionFormatConverter.get_body_text(value)
+        if "focal" in key: result = CaptionFormatConverter.get_focal_text(value)
+        if key == "{aper}": result = CaptionFormatConverter.get_aperture_text(value)
+        if key == "{iso}": result = CaptionFormatConverter.get_iso_text(value)
+        if key == "{ss}": result = CaptionFormatConverter.get_shutterspeed_text(value)
+        if key == "{ev}": result = CaptionFormatConverter.get_exposure_text(value)
+        if key == "{meter}": result = CaptionFormatConverter.get_metering_text(value)
+        if key == "{mode}": result = CaptionFormatConverter.get_mode_text(value)
+        if key == "{ar}": result = CaptionFormatConverter.get_artist_text(value)
+
+        if exif_data:
+            print("[" + key + "]: value " + result + " found (original value: " + str(value) + ")")
+
+        return result
+
+
+
+    @staticmethod
+    def get_body_text(body_value) -> str:
+        return ModelNameMapper.replace_model_name(str(body_value))        
+    
+    @staticmethod
+    def get_focal_text(focal_length) -> str:
+        return str(int(round(focal_length))) + "mm"
+    
+    @staticmethod
+    def get_aperture_text(aperture) -> str:
+        return "F/{:.1f}".format(float(aperture))
+    
+    @staticmethod
+    def get_iso_text(iso) -> str:
+        return "ISO " + str(iso)
+    
+    @staticmethod
+    def get_shutterspeed_text(ss) -> str:
+        if ss < 1.0:
+            # note(komastar) : 1/1000s, 1/4000s ...
+            return f'1/{int(round(1.0 / ss))}s'
+        # note(komastar) : 1.0s, 30.0s ...
+        # note(canu): ,2 형식으로 변환시 TypeError string to Fraction.__format__ 발생..?
+        return f'{format(round(ss), ".1f")}s'
+
+    @staticmethod
+    def get_exposure_text(exposure_value) -> str:
+        str = "{:.2f}".format(float(exposure_value))
+        if exposure_value > 0: str = "+" + str
+        return "ev " + str
+    
+    @staticmethod
+    def get_metering_text(metering_value) -> str:
+        val = CaptionFormatConverter.dump_data
+        if metering_value == 1: val = "Average"
+        elif metering_value == 2: val = "Center-weighted"
+        elif metering_value == 3: val = "Spot"
+        elif metering_value == 4: val = "Multi-spot"
+        elif metering_value == 5: val = "Multi-segment"
+        elif metering_value == 6: val = "Partial"
+
+        return "Metering:" + val
+    
+    @staticmethod
+    def get_mode_text(mode_value) -> str:
+        if mode_value == 5: return "Slow Speed"
+        if mode_value == 6: return "High Speed"
+        if mode_value == 7: return "Portrait"
+        if mode_value == 8: return "Landscape"
+        
+        if mode_value == 0 or mode_value > 8: return CaptionFormatConverter.dump_data
+
+        val = "M"
+        if mode_value == 2: val = "P"
+        if mode_value == 3: val = "A"
+        if mode_value == 4: val = "S"
+        return "Mode:" + val
+    
+    @staticmethod
+    def get_artist_text(artist_value) -> str:
+        return "by " + str(artist_value)
+

--- a/caption_format_converter.py
+++ b/caption_format_converter.py
@@ -36,8 +36,7 @@ class CaptionFormatConverter():
             text_replaced = text
             for key in list(exif_actual_dic.keys()):
                 value = exif_actual_dic[key]
-                if value and value != CaptionFormatConverter.dump_data:
-                    text_replaced = text_replaced.replace(key, value)
+                text_replaced = text_replaced.replace(key, value)
         except Exception as e:
             print(e)
             print("데이터 불량, 콘솔 창의 기록을 댓글로 남겨주세요.")
@@ -99,8 +98,7 @@ class CaptionFormatConverter():
         if key == "{mode}": result = CaptionFormatConverter.get_mode_text(value)
         if key == "{ar}": result = CaptionFormatConverter.get_artist_text(value)
 
-        if exif_data:
-            print("[" + key + "]: value " + result + " found (original value: " + str(value) + ")")
+        #if exif_data: print("[" + key + "]: value " + result + " found (original value: " + str(value) + ")")
 
         return result
 

--- a/caption_format_converter.py
+++ b/caption_format_converter.py
@@ -22,7 +22,7 @@ class CaptionFormatConverter():
         "{cr}": (33432, "Copyrigth (C) Text here"),
         "{ar}": (315, "Artist Name"),
     }
-
+    
     @staticmethod
     def convert(text:str, exif_data=None) -> str:
         exif_actual_dic = {}
@@ -45,6 +45,37 @@ class CaptionFormatConverter():
 
         return text_replaced
     
+    def convert_easymode(one_line:bool, exif_data=None) -> str:
+        try:
+            body_value = CaptionFormatConverter.get_value_in_key("{body}", exif_data)
+            format_text = body_value
+
+            # on iPhone or Galaxy: do not show lens data
+            if "iPhone" in body_value or "Galaxy" in body_value:
+                lens_value = CaptionFormatConverter.dump_data
+            else:
+                lens_value = CaptionFormatConverter.get_value_in_key("{lens}", exif_data)
+            
+            if lens_value != CaptionFormatConverter.dump_data:
+                format_text += " | " + lens_value
+
+            if one_line: format_text += " | "
+            else: format_text += "\n"
+
+            focal_value = CaptionFormatConverter.get_value_in_key("{focal_f}", exif_data)
+            aperture_value = CaptionFormatConverter.get_value_in_key("{aper}", exif_data)
+            iso_value = CaptionFormatConverter.get_value_in_key("{iso}", exif_data)
+            ss_value = CaptionFormatConverter.get_value_in_key("{ss}", exif_data)
+
+            format_text += f"{focal_value} | {aperture_value} | {iso_value} | {ss_value}"
+            return format_text
+        
+        except Exception as e:
+            print(e)
+            print("데이터 불량, 콘솔 창의 기록을 댓글로 남겨주세요.")
+            return ""
+        
+     
     @staticmethod
     def get_value_in_key(key, exif_data) -> str:
         if key not in CaptionFormatConverter.exif_dic:

--- a/exif_module.py
+++ b/exif_module.py
@@ -41,7 +41,10 @@ class Exif:
             model = ModelNameMapper.replace_model_name(model)
 
             lens_model = str(exif_data.get(42036, self.dump_data))
-            f_number = str(exif_data.get(33437, self.dump_data))
+            f_number_raw = exif_data.get(33437, self.dump_data)
+            f_number = self.dump_data
+            if f_number_raw is not self.dump_data:
+                f_number = "{:.1f}".format(float(f_number_raw))
             focal_length = str(exif_data.get(41989, self.dump_data))
             iso = str(exif_data.get(34855, self.dump_data))
 
@@ -88,8 +91,9 @@ class Exif:
             print("ShutterSpeed: " + shutter_speed)
 
             try:
-                result_exif = focal_length + "mm | F/" + "{:.1f}".format(f_number) + " | " + "ISO " + iso + " | " + shutter_speed
-            except:
+                result_exif = focal_length + "mm | F/" + f_number + " | " + "ISO " + iso + " | " + shutter_speed
+            except Exception as e:
+                print(e)
                 print("데이터 불량, 콘솔 창의 기록을 댓글로 남겨주세요.")
 
             return result_model, result_exif

--- a/exif_module.py
+++ b/exif_module.py
@@ -6,17 +6,17 @@ import platform
 from PIL import Image, ImageDraw, ImageFont
 import math
 
-from model_name_mapper import ModelNameMapper
-
+from caption_format_converter import CaptionFormatConverter
 
 # 폰트 vs padding 비율은 1:4?
 # 이미지파일 vs padding 비율은 10:1
-
 
 class Exif:
     def __init__(self):
         # 폰트 사이즈 (초기)
         self.font_size = 50
+        self.ratio_image_gap = 60
+        self.side_padding_45 = 50
         # 폰트 (초기)
         if platform.system() == "Windows":
             self.font = ImageFont.truetype(os.path.join(os.getcwd(), 'Resources/Barlow-Light.ttf'), self.font_size)
@@ -25,81 +25,8 @@ class Exif:
                 self.font = ImageFont.truetype(os.path.join(os.path.dirname(sys.executable), "Resources/Barlow-Light.ttf"), self.font_size)
             except:
                 self.font = ImageFont.truetype(os.path.join(os.getcwd(), 'Resources/Barlow-Light.ttf'), self.font_size)
-        self.dump_data = "NONEDATA"
 
-    def get_exif_data(self, image):
-        exif_data = image._getexif()
-        result_exif = None
-
-        if exif_data is None:
-            print('Sorry, image has no exif data.')
-            return None, image
- 
-        else:
-            # 데이터 읽어오기
-            model = str(exif_data.get(272, self.dump_data))
-            model = ModelNameMapper.replace_model_name(model)
-
-            lens_model = str(exif_data.get(42036, self.dump_data))
-            f_number_raw = exif_data.get(33437, self.dump_data)
-            f_number = self.dump_data
-            if f_number_raw is not self.dump_data:
-                f_number = "{:.1f}".format(float(f_number_raw))
-            focal_length = str(exif_data.get(41989, self.dump_data))
-            iso = str(exif_data.get(34855, self.dump_data))
-
-            shutter_speed_value = exif_data.get(33434, None)
-            shutter_speed = self.dump_data
-            if shutter_speed_value:
-                if shutter_speed_value < 1.0:
-                    # note(komastar) : 1/1000s, 1/4000s ...
-                    shutter_speed = f'1/{int(round(1.0 / shutter_speed_value))}s'
-                else:
-                    # note(komastar) : 1.0s, 30.0s ...
-                    # note(canu): ,2 형식으로 변환시 TypeError string to Fraction.__format__ 발생..?
-                    shutter_speed = f'{format(round(shutter_speed_value), ".1f")}s'
-
-            if lens_model is self.dump_data or 'iPhone' in model:
-                print("Model: " + model)
-                result_model = model
-            else:
-                print("Model: " + model)
-                print("Lens: " + lens_model)
-                result_model = model + " | " + lens_model
-
-            if focal_length is self.dump_data:
-                try:
-                    focal_length = str(exif_data[37386])  # 소수점
-                except KeyError:
-                    print("Focal Length 데이터가 없습니다.")
-                    focal_length = self.dump_data
-            else:
-                pass
-
-            if f_number is self.dump_data:
-                print("조리개 데이터가 없습니다.")
-
-            if iso is self.dump_data:
-                print("ISO 데이터가 없습니다.")
-
-            if shutter_speed is self.dump_data:
-                print("셔터스피드 데이터가 없습니다.")
-
-            print("FocalLength: " + focal_length)
-            print("fNumber: " + f_number)
-            print("ISO: " + iso)
-            print("ShutterSpeed: " + shutter_speed)
-
-            try:
-                result_exif = focal_length + "mm | F/" + f_number + " | " + "ISO " + iso + " | " + shutter_speed
-            except Exception as e:
-                print(e)
-                print("데이터 불량, 콘솔 창의 기록을 댓글로 남겨주세요.")
-
-            return result_model, result_exif
-
-    @staticmethod
-    def set_image_padding(image, length, color):
+    def set_image_padding(self, image, length, color):
         width, height = image.size
         new_width = width + 2 * length
         new_height = height + 2 * length
@@ -109,56 +36,45 @@ class Exif:
 
         return result
 
-    @staticmethod
-    def set_image_padding2(image, top, side, bottom, color):
+    def set_image_padding2(self, image, top, side, bottom, color):
         width, height = image.size
 
         new_width = width + 2 * side
-        new_height = height + 2 + top + bottom
+        new_height = height + top + bottom
 
         result = Image.new(image.mode, (new_width, new_height), color)
         result.paste(image, (side, top))
 
         return result
         
-    def set_image_text(self, image, model_data, exif_data, length, font_path, color):
+    def set_image_text(self, image, text, length, font_path, color, alignment):
         draw = ImageDraw.Draw(image)
 
         x = image.width / 2
         y = image.height - (length / 2)
         anchor = "ms"
+        align = "center"
 
-        alignment = 1 #temporary
         if alignment is 1:
             x = length / 2
             anchor = "ls"
+            align = "left"
         elif alignment is 2:
             x = image.width - (length / 2)
             anchor = "rs"
-
-        self.font_size = length / 4.5
-        self.font = ImageFont.truetype(font_path, self.font_size)
-
-        draw.text(xy=(x, y - self.font_size / 2), text=model_data, font=self.font, fill=color, anchor=anchor)
-        draw.text(xy=(x, y + self.font_size), text=exif_data, font=self.font, fill=color, anchor=anchor)
-
-        return image   
-
-    def set_line_text(self, image, model_data, exif_data, length, font_path, color):
-        draw = ImageDraw.Draw(image)
-        x = image.width / 2
-        y = image.height - (length / 2)
-        merged_text = model_data + " | " + exif_data
+            align = "right"
 
         self.font_size = length / 6
+
+        line_count = len(text.splitlines())
+        if line_count >= 2:
+            self.font_size = length / 4.5
+
         self.font = ImageFont.truetype(font_path, self.font_size)
-
-        draw.text(xy=(x, y), text=merged_text, font=self.font, fill=color, anchor="ms")
-
+        draw.text(xy=(x, y), text=text, font=self.font, fill=color, anchor=anchor, align=align)
         return image
 
-    @staticmethod            
-    def set_square_padding(image, gap, color, horizontalImage):
+    def set_square_padding(self, image, gap, color, horizontalImage):
         width, height = image.size
         instaSize = 1440
         ratio = width / height     
@@ -167,6 +83,8 @@ class Exif:
         newHeight = 0
         newX = 0
         newY = 0
+
+        self.ratio_image_gap = gap
 
         if (horizontalImage) : 			
             newWidth = instaSize - 2*gap
@@ -194,28 +112,97 @@ class Exif:
         resizedImage = image.resize((newWidth,newHeight))		
         result.paste(resizedImage, (newX, newY))
         return result	
+    
+    def set_45_padding(self, image, gap, color):
+        #instagram 4:5 image size
+        width = 1080
+        height = 1350
 
-    def set_square_text(self, image, model_data, font_path, exif_data, color, horizontalImage):
+        self.ratio_image_gap = gap
+
+        width_actual = width - gap * 2
+        height_actual = height - gap * 3
+
+        image_width = width
+        image_height = height
+        image_x = 0
+        image_y = 0
+
+        image_raw_width, image_raw_height = image.size
+
+        horizontal_image = image_raw_width / image_raw_height > width_actual / height_actual
+
+        if horizontal_image:
+            image_width = width_actual
+            image_height = math.floor(image_width * image_raw_height / image_raw_width)
+            image_x = gap
+            image_y = gap + math.floor((height_actual - image_height) / 2)
+        else:
+            image_height = height_actual
+            image_width = math.floor(image_height * image_raw_width / image_raw_height)
+            image_y = gap
+            image_x = gap + math.floor((width_actual - image_width) / 2)
+            
+        self.side_padding_45 = image_x
+
+        result = Image.new(image.mode, (width, height), color)
+        resized_image = image.resize((image_width, image_height))
+        result.paste(resized_image, (image_x, image_y))
+        return result
+
+
+    def set_square_text(self, image, text, font_path, color, horizontalImage, alignment):
         self.font_size = 46
         self.font = ImageFont.truetype(font_path, self.font_size)
         if(horizontalImage) : 
             rotateImage = image
-
         else :
             rotateImage = image.rotate(-90)
 
         draw = ImageDraw.Draw(rotateImage)
         x = image.width / 2
-        y = image.height - self.font_size*3
+        y = image.height - self.font_size * 3
+        anchor = "ms"
+        align = "center"
 
-        draw.text(xy = (x,y - self.font_size / 2), text = model_data,font=self.font, fill=color, anchor="ms")
-        draw.text(xy = (x,y + self.font_size), text = exif_data,font=self.font, fill=color, anchor="ms")
+        if alignment is 1:
+            x = self.ratio_image_gap
+            anchor = "ls"
+            align = "left"
+        elif alignment is 2:
+            x = image.width - self.ratio_image_gap
+            anchor = "rs"
+            align = "right"
+
+        draw.text(xy = (x,y), text = text,font=self.font, fill=color, anchor=anchor, align=align)
         if(horizontalImage) : 
             image = rotateImage
 
         else :
             image = rotateImage.rotate(90)
 
+        return image
+    
+    def set_45_text(self, image, text, font_path, color, alignment):
+        self.font_size = self.ratio_image_gap / 2
+
+        x = image.width / 2
+        y = image.height - (self.ratio_image_gap * 1.125)
+        anchor = "ms"
+        align = "center"
+
+        if alignment is 1:
+            x = self.side_padding_45
+            anchor = "ls"
+            align = "left"
+        elif alignment is 2:
+            x = image.width - self.side_padding_45
+            anchor = "rs"
+            align = "right"
+
+        self.font = ImageFont.truetype(font_path, self.font_size)
+        draw = ImageDraw.Draw(image)
+        draw.text(xy=(x, y), text=text, font=self.font, fill=color, anchor=anchor, align=align)
         return image
 
 
@@ -227,10 +214,10 @@ def main():
     longer_length = img.width if img.width >= img.height else img.height
     padding = int(longer_length / 10)
 
-    model_data, exif_data = exif_test.get_exif_data(img)
+    text = CaptionFormatConverter.convert("{body} | {lens}\n{focal_f} | {aper} | {iso} | {ss}", img._getexif())
     img = Exif.set_image_padding2(img, top=int(padding / 2), side=int(padding / 2), bottom=padding,
                                   color=(255, 255, 255))
-    img = exif_test.set_image_text(img, model_data=model_data, exif_data=exif_data, length=padding, font_path="Resources/Barlow-Light.ttf", color=(0,0,0))
+    img = exif_test.set_image_text(img, text=text, length=padding, font_path="Resources/Barlow-Light.ttf", color=(0,0,0), alignment=0)
     img.show()
 
     img.save("Test.jpg")

--- a/exif_module.py
+++ b/exif_module.py
@@ -123,14 +123,24 @@ class Exif:
         
     def set_image_text(self, image, model_data, exif_data, length, font_path, color):
         draw = ImageDraw.Draw(image)
+
         x = image.width / 2
         y = image.height - (length / 2)
+        anchor = "ms"
+
+        alignment = 1 #temporary
+        if alignment is 1:
+            x = length / 2
+            anchor = "ls"
+        elif alignment is 2:
+            x = image.width - (length / 2)
+            anchor = "rs"
 
         self.font_size = length / 4.5
         self.font = ImageFont.truetype(font_path, self.font_size)
 
-        draw.text(xy=(x, y - self.font_size / 2), text=model_data, font=self.font, fill=color, anchor="ms")
-        draw.text(xy=(x, y + self.font_size), text=exif_data, font=self.font, fill=color, anchor="ms")
+        draw.text(xy=(x, y - self.font_size / 2), text=model_data, font=self.font, fill=color, anchor=anchor)
+        draw.text(xy=(x, y + self.font_size), text=exif_data, font=self.font, fill=color, anchor=anchor)
 
         return image   
 

--- a/exif_module.py
+++ b/exif_module.py
@@ -26,17 +26,7 @@ class Exif:
             except:
                 self.font = ImageFont.truetype(os.path.join(os.getcwd(), 'Resources/Barlow-Light.ttf'), self.font_size)
 
-    def set_image_padding(self, image, length, color):
-        width, height = image.size
-        new_width = width + 2 * length
-        new_height = height + 2 * length
-
-        result = Image.new(image.mode, (new_width, new_height), color)
-        result.paste(image, (length, length))
-
-        return result
-
-    def set_image_padding2(self, image, top, side, bottom, color):
+    def set_image_padding(self, image, top, side, bottom, color):
         width, height = image.size
 
         new_width = width + 2 * side
@@ -67,11 +57,16 @@ class Exif:
         self.font_size = length / 6
 
         line_count = len(text.splitlines())
-        if line_count >= 2:
-            self.font_size = length / 4.5
+        if line_count == 1:
+            y += math.floor(self.font_size / 3)
+        elif line_count == 2:
+            self.font_size *= 4 / 3
+            y -= math.floor(self.font_size / 2)
+        else: #line_count == 3, 4 and more is not regarded
+            y -= math.floor(self.font_size)
 
         self.font = ImageFont.truetype(font_path, self.font_size)
-        draw.text(xy=(x, y), text=text, font=self.font, fill=color, anchor=anchor, align=align)
+        draw.text(xy=(x, y), text=text, font=self.font, fill=color, anchor=anchor, align=align, spacing=math.floor(self.font_size / 2))
         return image
 
     def set_square_padding(self, image, gap, color, horizontalImage):
@@ -113,6 +108,47 @@ class Exif:
         result.paste(resizedImage, (newX, newY))
         return result	
     
+    def set_square_text(self, image, text, font_path, color, horizontalImage, alignment):
+        self.font_size = 46
+        if(horizontalImage) : 
+            rotateImage = image
+        else :
+            rotateImage = image.rotate(-90)
+
+        draw = ImageDraw.Draw(rotateImage)
+        x = image.width / 2
+        y = image.height - self.font_size * 3
+        anchor = "ms"
+        align = "center"
+
+        if alignment is 1:
+            x = self.ratio_image_gap
+            anchor = "ls"
+            align = "left"
+        elif alignment is 2:
+            x = image.width - self.ratio_image_gap
+            anchor = "rs"
+            align = "right"
+
+        line_count = len(text.splitlines())
+        if line_count == 1:
+            self.font_size /= 1.15
+            y += math.floor(self.font_size / 3)
+        elif line_count == 2:
+            y -= math.floor(self.font_size / 2)
+        else: #line_count == 3, 4 and more is not regarded
+            y -= math.floor(self.font_size)
+
+        self.font = ImageFont.truetype(font_path, self.font_size)
+        draw.text(xy = (x,y), text = text,font=self.font, fill=color, anchor=anchor, align=align, spacing=math.floor(self.font_size / 2))
+        if(horizontalImage) : 
+            image = rotateImage
+
+        else :
+            image = rotateImage.rotate(90)
+
+        return image
+    
     def set_45_padding(self, image, gap, color):
         #instagram 4:5 image size
         width = 1080
@@ -149,45 +185,12 @@ class Exif:
         resized_image = image.resize((image_width, image_height))
         result.paste(resized_image, (image_x, image_y))
         return result
-
-
-    def set_square_text(self, image, text, font_path, color, horizontalImage, alignment):
-        self.font_size = 46
-        self.font = ImageFont.truetype(font_path, self.font_size)
-        if(horizontalImage) : 
-            rotateImage = image
-        else :
-            rotateImage = image.rotate(-90)
-
-        draw = ImageDraw.Draw(rotateImage)
-        x = image.width / 2
-        y = image.height - self.font_size * 3
-        anchor = "ms"
-        align = "center"
-
-        if alignment is 1:
-            x = self.ratio_image_gap
-            anchor = "ls"
-            align = "left"
-        elif alignment is 2:
-            x = image.width - self.ratio_image_gap
-            anchor = "rs"
-            align = "right"
-
-        draw.text(xy = (x,y), text = text,font=self.font, fill=color, anchor=anchor, align=align)
-        if(horizontalImage) : 
-            image = rotateImage
-
-        else :
-            image = rotateImage.rotate(90)
-
-        return image
-    
+        
     def set_45_text(self, image, text, font_path, color, alignment):
         self.font_size = self.ratio_image_gap / 2
 
         x = image.width / 2
-        y = image.height - (self.ratio_image_gap * 1.125)
+        y = image.height - self.ratio_image_gap
         anchor = "ms"
         align = "center"
 
@@ -200,9 +203,19 @@ class Exif:
             anchor = "rs"
             align = "right"
 
+        line_count = len(text.splitlines())
+        if line_count == 1:
+            self.font_size /= 1.15
+            y += math.floor(self.font_size / 2)
+        elif line_count == 2:
+            y -= math.floor(self.font_size / 2.125)
+        else: #line_count == 3, 4 and more is not regarded
+            self.font_size /= 1.15
+            y -= math.floor(self.font_size)
+
         self.font = ImageFont.truetype(font_path, self.font_size)
         draw = ImageDraw.Draw(image)
-        draw.text(xy=(x, y), text=text, font=self.font, fill=color, anchor=anchor, align=align)
+        draw.text(xy=(x, y), text=text, font=self.font, fill=color, anchor=anchor, align=align, spacing=math.floor(self.font_size / 2))
         return image
 
 

--- a/option_window/exif_option_window.py
+++ b/option_window/exif_option_window.py
@@ -270,5 +270,5 @@ class ExifOptionWindow(QDialog, formClass):
 		self.format_preview_area.setText(text)
 
 	def get_current_font_path(self):
-		self.selected_font = self.font_combo_box.itemData(UserConfig.exif_font_index)
-		return self.selected_font
+		itemData = self.font_combo_box.itemData(UserConfig.exif_font_index)
+		return itemData[0]

--- a/option_window/exif_option_window.py
+++ b/option_window/exif_option_window.py
@@ -4,6 +4,7 @@ import platform
 import pathlib
 
 from user_config import UserConfig
+from caption_format_converter import CaptionFormatConverter
 
 from PyQt6 import uic
 from PyQt6.QtCore import Qt
@@ -37,6 +38,7 @@ class ExifOptionWindow(QDialog, formClass):
 		self.image_ratio = 0
 		self.image_type = 2
 		self.image_quality_option = 80
+		self.caption_format = ""
 
 		# UI 링킹 설정 (EXIF Options)
 		self.exif_option_button_box: QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
@@ -147,12 +149,12 @@ class ExifOptionWindow(QDialog, formClass):
 		if self.image_quality_spinbox.value() != UserConfig.exif_quality:
 			self.image_quality_spinbox.setValue(UserConfig.exif_quality)
 
-		if self.font_combo_box.currentIndex() != UserConfig.exif_font:
+		if self.font_combo_box.currentIndex() != UserConfig.exif_font_index:
 			# if folder data is changed from previous run
-			if UserConfig.exif_font >= self.font_combo_box.count():
-				UserConfig.exif_font = 1
-			self.font_combo_box.setCurrentIndex(UserConfig.exif_font)
-			self.selected_font = self.font_combo_box.itemData(UserConfig.exif_font)
+			if UserConfig.exif_font_index >= self.font_combo_box.count():
+				UserConfig.exif_font_index = 1
+			self.font_combo_box.setCurrentIndex(UserConfig.exif_font_index)
+			self.selected_font = self.font_combo_box.itemData(UserConfig.exif_font_index)
 
 		if self.alignment_combo_box.currentIndex() != UserConfig.exif_format_alignment:
 			self.alignment_combo_box.setCurrentIndex(UserConfig.exif_format_alignment)
@@ -178,7 +180,7 @@ class ExifOptionWindow(QDialog, formClass):
 		UserConfig.exif_quality = self.image_quality_option
 		UserConfig.exif_text_color = self.text_color
 		UserConfig.exif_bg_color = self.background_color
-		UserConfig.exif_font = self.font_index
+		UserConfig.exif_font_index = self.font_index
 		UserConfig.exif_format_alignment = self.font_alignment
 		UserConfig.exif_format = self.caption_format
 		UserConfig.save()
@@ -251,4 +253,9 @@ class ExifOptionWindow(QDialog, formClass):
 
 		self.format_preview_area.setAlignment(alignment)
 		self.format_preview_area.setStyleSheet(f"background-color: {self.background_color.name()}; color: {self.text_color.name()};")
-		self.format_preview_area.setText(self.format_input_area.toPlainText())
+		text = CaptionFormatConverter.convert(self.format_input_area.toPlainText())
+		self.format_preview_area.setText(text)
+
+	def get_current_font_path(self):
+		self.selected_font = self.font_combo_box.itemData(UserConfig.exif_font_index)
+		return self.selected_font

--- a/option_window/exif_option_window.py
+++ b/option_window/exif_option_window.py
@@ -273,9 +273,6 @@ class ExifOptionWindow(QDialog, formClass):
 
 	def on_exif_easy_mode_toggled(self, state):
 		self.easy_mode_enable = bool(state == Qt.CheckState.Checked.value)
-		self.format_input_area.setVisible(not self.easy_mode_enable)
-		self.enable_easymode_oneline_box.setVisible(self.easy_mode_enable)
-
 		self.__update_font_preview()
 
 	def on_exif_easy_mode_oneline_toggled(self, state):
@@ -283,6 +280,9 @@ class ExifOptionWindow(QDialog, formClass):
 		self.__update_font_preview() 
 
 	def __update_font_preview(self):
+		self.format_input_area.setEnabled(not self.easy_mode_enable)
+		self.enable_easymode_oneline_box.setEnabled(self.easy_mode_enable)
+
 		if self.__selected_font_style:
 			font = QFontDatabase.font(self.__selected_font_family, self.__selected_font_style, self.__font_preview_size)
 			self.format_preview_area.setFont(font)

--- a/option_window/exif_option_window.py
+++ b/option_window/exif_option_window.py
@@ -138,8 +138,8 @@ class ExifOptionWindow(QDialog, formClass):
 		
 		# COLORPICKER OPTIONS
 		UserConfig.load()
-		if UserConfig.background_color:
-			self.background_color = UserConfig.background_color
+		if UserConfig.exif_bg_color:
+			self.background_color = UserConfig.exif_bg_color
 
 		# BACKUP EXIF OPTIONS
 		self.backup_enable_padding = self.enable_padding

--- a/option_window/exif_option_window.py
+++ b/option_window/exif_option_window.py
@@ -27,6 +27,9 @@ class ExifOptionWindow(QDialog, formClass):
 	def __init__(self):
 		super().__init__()
 
+		# External EXIF data variable
+		self.selected_exif_data = None
+
 		# 기타 참조 변수
 		self.default_font = 'Barlow-Light'
 		self.__font_preview_size = 14
@@ -294,9 +297,9 @@ class ExifOptionWindow(QDialog, formClass):
 		self.format_preview_area.setStyleSheet(f"background-color: {self.background_color.name()}; color: {self.text_color.name()};")
 
 		if self.easy_mode_enable:
-			text = CaptionFormatConverter.convert_easymode(self.easy_mode_oneline)
+			text = CaptionFormatConverter.convert_easymode(self.easy_mode_oneline, self.selected_exif_data)
 		else:
-			text = CaptionFormatConverter.convert(self.format_input_area.toPlainText())
+			text = CaptionFormatConverter.convert(self.format_input_area.toPlainText(), self.selected_exif_data)
 		
 		self.format_preview_area.setText(text)
 

--- a/option_window/resize_option_window.py
+++ b/option_window/resize_option_window.py
@@ -51,6 +51,12 @@ class ResizeOptionWindow(QDialog, formClass):
 
     def init_options(self):
         self.axis_option_box.addItems(['Width', 'Height', 'Longest', 'Shortest'])
+
+    def on_call(self):
+        self.__update_ui()
+        self.show()
+          
+    def __update_ui(self):
         index = UserConfig.resize_axis
         self.axis_option_box.setCurrentIndex(index)
 
@@ -59,14 +65,9 @@ class ResizeOptionWindow(QDialog, formClass):
 
     def on_axis_option_box_index_changed(self, index):
         self.axis_option = index
-        print("Axis Changed", UserConfig.resize_axis, index)
-        UserConfig.resize_axis = index
-        UserConfig.save()
-        
+
     def on_change_resize_value(self):
         self.resize_value = self.resize_value_box.value()
-        UserConfig.resize_size = self.resize_value
-        UserConfig.save()
 
     def __update_size_info(self):
         '''
@@ -78,5 +79,9 @@ class ResizeOptionWindow(QDialog, formClass):
         self.__update_size_info()
         if self.on_accepted:
             print(self.axis_option, self.resize_value)
+            UserConfig.resize_axis = self.axis_option
+            UserConfig.resize_size = self.resize_value
+            UserConfig.save()
+
             self.on_accepted(self.axis_option, self.resize_value)
         super().accept()

--- a/option_window/resize_option_window.py
+++ b/option_window/resize_option_window.py
@@ -5,7 +5,8 @@ import platform
 
 from PyQt6 import uic
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QDialogButtonBox, QSpinBox, QDialog, QCheckBox
+from PyQt6.QtWidgets import QDialogButtonBox, QSpinBox, QDialog, QComboBox
+from user_config import UserConfig
 
 if platform.system() == "Windows":
     form = os.path.join(os.getcwd(), "Resources/ResizeOption.ui")
@@ -26,12 +27,10 @@ class ResizeOptionWindow(QDialog, formClass):
         self.base_size = 3000
 
         self.resize_option_button_box: QDialogButtonBox
-        self.width_option_box: QCheckBox
-        self.height_option_box: QCheckBox
+        self.axis_option_box: QComboBox
+        
         self.resize_value_box: QSpinBox
-
-        self.width_option = True
-        self.height_option = False
+        self.axis_option = 2
         self.resize_value = self.base_size
 
         self.setupUi(self)
@@ -44,30 +43,30 @@ class ResizeOptionWindow(QDialog, formClass):
         self.on_accepted = None
 
     def bind_ui(self):
-        self.width_option_box.stateChanged.connect(self.on_toggle_width_option)
-        self.width_option_box.setToolTip("이미지 너비 기준")
-
-        self.height_option_box.stateChanged.connect(self.on_toggle_height_option)
-        self.height_option_box.setToolTip("이미지 높이 기준")
+        self.axis_option_box.currentIndexChanged.connect(self.on_axis_option_box_index_changed)
+        self.axis_option_box.setToolTip("순서대로 가로/세로/장축/단축 기준으로 리사이즈 됩니다.")
 
         self.resize_value_box.valueChanged.connect(self.on_change_resize_value)
         self.resize_value_box.setToolTip("체크된 높이 기준으로 리사이즈 됩니다.")
 
     def init_options(self):
-        self.width_option = self.width_option_box.isChecked()
-        self.height_option = self.height_option_box.isChecked()
-        self.resize_value = self.resize_value_box.value()
+        self.axis_option_box.addItems(['Width', 'Height', 'Longest', 'Shortest'])
+        index = UserConfig.resize_axis
+        self.axis_option_box.setCurrentIndex(index)
 
-    def on_toggle_width_option(self, state):
-        self.width_option = bool(state == Qt.CheckState.Checked.value)
-        self.height_option_box.setChecked(not state)
+        size = UserConfig.resize_size
+        self.resize_value_box.setValue(size)
 
-    def on_toggle_height_option(self, state):
-        self.height_option = bool(state == Qt.CheckState.Checked.value)
-        self.width_option_box.setChecked(not state)
-
+    def on_axis_option_box_index_changed(self, index):
+        self.axis_option = index
+        print("Axis Changed", UserConfig.resize_axis, index)
+        UserConfig.resize_axis = index
+        UserConfig.save()
+        
     def on_change_resize_value(self):
         self.resize_value = self.resize_value_box.value()
+        UserConfig.resize_size = self.resize_value
+        UserConfig.save()
 
     def __update_size_info(self):
         '''
@@ -78,6 +77,6 @@ class ResizeOptionWindow(QDialog, formClass):
     def accept(self) -> None:
         self.__update_size_info()
         if self.on_accepted:
-            print(self.width_option, self.height_option, self.resize_value)
-            self.on_accepted(self.width_option, self.height_option, self.resize_value)
+            print(self.axis_option, self.resize_value)
+            self.on_accepted(self.axis_option, self.resize_value)
         super().accept()

--- a/option_window/resize_option_window.py
+++ b/option_window/resize_option_window.py
@@ -35,7 +35,6 @@ class ResizeOptionWindow(QDialog, formClass):
 
         self.setupUi(self)
         self.bind_ui()
-        self.init_options()
         # 기본 리사이징 사이즈 (3000px)
 
         self.__update_size_info()
@@ -48,9 +47,6 @@ class ResizeOptionWindow(QDialog, formClass):
 
         self.resize_value_box.valueChanged.connect(self.on_change_resize_value)
         self.resize_value_box.setToolTip("체크된 높이 기준으로 리사이즈 됩니다.")
-
-    def init_options(self):
-        self.axis_option_box.addItems(['Width', 'Height', 'Longest', 'Shortest'])
 
     def on_call(self):
         self.__update_ui()

--- a/option_window/webp_option_window.py
+++ b/option_window/webp_option_window.py
@@ -60,7 +60,7 @@ class WebPOptionWindow(QDialog, formClass):
 		self.exact_option_box.setToolTip("몰?루... 저장 옵션")
 
 		self.image_quality_spinbox.valueChanged.connect(self.on_change_image_quality)
-		self.image_quality_spinbox.setToolTip("이미지 품질 저장 옵션 \n 92 정도가 web에서 사용하기 제일 좋습니다.")
+		self.image_quality_spinbox.setToolTip("이미지 품질 저장 옵션\n92 정도가 web에서 사용하기 제일 좋습니다.")
 
 	# DEBUG LOGGER FUNCTIONS
 	def debug_log(self, options=int):

--- a/option_window/webp_option_window.py
+++ b/option_window/webp_option_window.py
@@ -6,6 +6,8 @@ from PyQt6 import uic
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QDialogButtonBox, QDialog, QCheckBox, QSpinBox, QPushButton
 
+from user_config import UserConfig
+
 if platform.system() == "Windows":
 	form = os.path.join(os.getcwd(), "Resources/ConversionOptions.ui")
 else:
@@ -37,13 +39,6 @@ class WebPOptionWindow(QDialog, formClass):
 		self.icc_profile_option = False
 		self.exact_option = False
 		self.image_quality_option = 80
-
-		# Cancel 시 revert 시킬 옵션 값 backup
-		self.backup_loseless_option = False
-		self.backup_exif_option = False
-		self.backup_icc_profile_option = False
-		self.backup_exact_option = False
-		self.backup_image_quality_option = 80
 
 		self.setupUi(self)
 		self.bind_ui()
@@ -116,39 +111,37 @@ class WebPOptionWindow(QDialog, formClass):
 		self.debug_log(5)
 	
 	def __update_ui(self):
-		if self.loseless_option_box.isChecked() != self.loseless_option:
+		if self.loseless_option_box.isChecked() != UserConfig.conversion_loseless:
 			self.loseless_option_box.toggle()
 
-		if self.exif_option_box.isChecked() != self.exif_option:
+		if self.exif_option_box.isChecked() != UserConfig.conversion_exif:
 			self.exif_option_box.toggle()
 
-		if self.icc_profile_option_box.isChecked() != self.icc_profile_option:
+		if self.icc_profile_option_box.isChecked() != UserConfig.conversion_icc:
 			self.icc_profile_option_box.toggle()
 
-		if self.exact_option_box.isChecked() != self.exact_option:
+		if self.exact_option_box.isChecked() != UserConfig.conversion_transparent:
 			self.exact_option_box.toggle()
 
-		if self.image_quality_spinbox.value() != self.image_quality_option:
-			self.image_quality_spinbox.setValue(self.image_quality_option)
+		if self.image_quality_spinbox.value() != UserConfig.conversion_quality:
+			self.image_quality_spinbox.setValue(UserConfig.conversion_quality)
 
 	def on_call(self):
 		self.__update_ui()
 		self.show()
 
 	def on_save_close(self):
-		self.backup_loseless_option = self.loseless_option
-		self.backup_exif_option = self.exif_option
-		self.backup_icc_profile_option = self.icc_profile_option
-		self.backup_exact_option = self.exact_option
-		self.backup_image_quality_option = self.image_quality_option
 		self.debug_log(0)
+
+		UserConfig.conversion_loseless = self.loseless_option
+		UserConfig.conversion_exif = self.exif_option
+		UserConfig.conversion_icc = self.icc_profile_option
+		UserConfig.conversion_transparent = self.exact_option
+		UserConfig.conversion_quality = self.image_quality_option
+		UserConfig.save()
+
 		self.accept()
 	
 	def on_cancel_close(self):
-		self.loseless_option = self.backup_loseless_option
-		self.exif_option = self.backup_exif_option
-		self.icc_profile_option = self.backup_icc_profile_option
-		self.exact_option = self.backup_exact_option
-		self.image_quality_option = self.backup_image_quality_option
 		self.debug_log(0)
 		self.reject()

--- a/resize_module.py
+++ b/resize_module.py
@@ -4,8 +4,14 @@ class Resize:
 	def __init__(self):
 		pass
 
-	def resize(self, image, width_option, height_option, resize):
+	def resize(self, image, axis_option, resize):
 		width, height = image.size
+
+		width_option = True
+		if axis_option is 0: width_option = True
+		elif axis_option is 1: width_option = False
+		elif axis_option is 2: width_option = width >= height
+		elif axis_option is 3: width_option = width < height
 
 		if width_option == True:
 			new_width = resize

--- a/user_config/user_config.py
+++ b/user_config/user_config.py
@@ -34,8 +34,8 @@ class UserConfig:
     exif_type = 2 # 0:JPEG, 1:PNG, 2:WebP, name changed from format
     exif_text_color = QColor(0, 0, 0) # replacement of white text
     exif_bg_color = QColor(255, 255, 255)
-    exif_format = "{body} | {lens}\n{focal_length_ff} | {aperture} | {iso} | {shutter_speed}" # replacement of 1 line text
-    exif_font = 1 # index of font list
+    exif_format = "{body} | {lens}\n{focal_f} | {aper} | {iso} | {ss}" # replacement of 1 line text
+    exif_font_index = 1 # index of font list
     exif_format_alignment = 0 # 0:Center, 1:Left, 2:Right
 
     @staticmethod

--- a/user_config/user_config.py
+++ b/user_config/user_config.py
@@ -17,7 +17,7 @@ class UserConfig:
 
     resize_options = False
     resize_axis = 2 # 0:Width, 1:Height, 2:Longest, 3:Shortest
-    resize_size = 2000
+    resize_size = 3000
 
     conversion_options = True
     conversion_loseless = False

--- a/user_config/user_config.py
+++ b/user_config/user_config.py
@@ -28,12 +28,15 @@ class UserConfig:
     
     exif_options = False
     exif_padding = False
-    exif_format = "{body} | {lens}\n{focal_length_ff} | {aperture} | {iso} | {shutter_speed}" # replacement of 1 line text
+    exif_save_exifdata = False
+    exif_quality = 80
     exif_ratio = 0 # 0:Original, 1:Square, 2:4:5, replacement of Square Mode
-    exif_type = 0 # 0:JPEG, 1:PNG, 2:WebP, name changed from format
+    exif_type = 2 # 0:JPEG, 1:PNG, 2:WebP, name changed from format
     exif_text_color = QColor(0, 0, 0) # replacement of white text
     exif_bg_color = QColor(255, 255, 255)
+    exif_format = "{body} | {lens}\n{focal_length_ff} | {aperture} | {iso} | {shutter_speed}" # replacement of 1 line text
     exif_font = 1 # index of font list
+    exif_format_alignment = 0 # 0:Center, 1:Left, 2:Right
 
     @staticmethod
     def save():

--- a/user_config/user_config.py
+++ b/user_config/user_config.py
@@ -24,16 +24,18 @@ class UserConfig:
     conversion_exif = False
     conversion_icc = False
     conversion_transparent = False
-    conversion_quality = 80
+    conversion_quality = 92
     
     exif_options = False
     exif_padding = False
     exif_save_exifdata = False
-    exif_quality = 80
+    exif_quality = 92
     exif_ratio = 0 # 0:Original, 1:Square, 2:4:5, replacement of Square Mode
     exif_type = 2 # 0:JPEG, 1:PNG, 2:WebP, name changed from format
     exif_text_color = QColor(0, 0, 0) # replacement of white text
     exif_bg_color = QColor(255, 255, 255)
+    exif_easymode_options = True
+    exif_easymode_oneline = False
     exif_format = "{body} | {lens}\n{focal_f} | {aper} | {iso} | {ss}" # replacement of 1 line text
     exif_font_index = 1 # index of font list
     exif_format_alignment = 0 # 0:Center, 1:Left, 2:Right

--- a/webp/webp_module.py
+++ b/webp/webp_module.py
@@ -52,7 +52,7 @@ class Converter:
 
     def convert_image_to_webp(self, file_path, save_path, save_name, loseless_option, image_quality_option,
                               exif_option, icc_profile_option, exact_option, watermark_text, exif_view_option,
-                              conversion_option, resize_option, width_option, height_option, resize_value):
+                              conversion_option, resize_option, axis_option, resize_value):
         file_format = Converter.search_file_format(file_path)
         # note(komastar) : file_format : 'jpg', 'png'...
         
@@ -73,8 +73,7 @@ class Converter:
             # Reize 하기
             if resize_option:
                 image = self.resize.resize(image, 
-                                    width_option,
-                                    height_option,
+                                    axis_option,
                                     resize_value)
 
             # Exif Option 데이터 읽어오기 / 오류시 except
@@ -117,7 +116,7 @@ class Converter:
 
     def convert_exif_image(self, file_path, save_path, save_name, file_format_option, font_path, 
                             bg_color, square_padding_option, dark_theme_option, exif_padding_option,
-                            one_line_option, save_exif_data_option, resize_option, width_option, height_option, resize_value):
+                            one_line_option, save_exif_data_option, resize_option, axis_option, resize_value):
         
         file_format = Converter.search_file_format(file_path)
 
@@ -170,8 +169,7 @@ class Converter:
         # Resize 하기
         if resize_option:
             image = self.resize.resize(image, 
-                                width_option,
-                                height_option,
+                                axis_option,
                                 resize_value)
         # 파일 형식 선택
         export_extension = Converter.FILE_FORMAT_EXTENSION[file_format_option]

--- a/webp/webp_module.py
+++ b/webp/webp_module.py
@@ -177,7 +177,7 @@ class Converter:
             image = self.exif.set_image_text(image=image, text=full_text, length=padding, font_path=font_path, color=font_color, alignment=alignment_option)
 
         else : 
-            image = self.exif.set_image_padding2(image, top=half_padding, side=half_padding, bottom=padding, color=background_color)
+            image = self.exif.set_image_padding(image, top=half_padding, side=half_padding, bottom=padding, color=background_color)
             image = self.exif.set_image_text(image=image, text=full_text, length=padding, font_path=font_path, color=font_color, alignment=alignment_option)
 
         # Resize 하기
@@ -233,7 +233,7 @@ class Converter:
             image = self.exif.set_image_text(image=image, text=full_text, length=padding, font_path=font_path, color=font_color, alignment=alignment_option)
 
         else : 
-            image = self.exif.set_image_padding2(image, top=half_padding, side=half_padding, bottom=padding, color=background_color)
+            image = self.exif.set_image_padding(image, top=half_padding, side=half_padding, bottom=padding, color=background_color)
             image = self.exif.set_image_text(image=image, text=full_text, length=padding, font_path=font_path, color=font_color, alignment=alignment_option)
 
         if platform.system() == "Darwin":

--- a/webp/webp_module.py
+++ b/webp/webp_module.py
@@ -22,6 +22,13 @@ class Converter:
         self.resize = resize_module.Resize()
 
     @staticmethod
+    def get_exif_data_on_path(file_path):
+        image = Image.open(file_path)
+        if image is None: return None
+
+        return image._getexif()
+
+    @staticmethod
     def fix_orientation(image):
         exif = image.getexif()
         print("Exif Type:", type(exif))

--- a/webp/webp_module.py
+++ b/webp/webp_module.py
@@ -116,7 +116,7 @@ class Converter:
 
     def convert_exif_image(self, file_path, save_path, save_name, file_format_option, font_path, 
                             bg_color, text_color, ratio_option, exif_padding_option, save_exif_data_option,
-                            resize_option, axis_option, alignment_option, resize_value, quality_option, caption_format):
+                            resize_option, axis_option, alignment_option, resize_value, quality_option, caption_format, easymode_option, easymode_oneline):
         
         file_format = Converter.search_file_format(file_path)
 
@@ -143,7 +143,10 @@ class Converter:
         else:
             new_exif_data, image = Converter.fix_orientation(image)
             
-        full_text = CaptionFormatConverter.convert(caption_format, raw_exif_data)
+        if not easymode_option:
+            full_text = CaptionFormatConverter.convert(caption_format, raw_exif_data)
+        else:
+            full_text = CaptionFormatConverter.convert_easymode(easymode_oneline, raw_exif_data)
 
         print('--- convert_exif_image ---')
         print(' file_path: ', file_path)
@@ -195,7 +198,7 @@ class Converter:
             image.save(fullpath, format=export_extension, quality=quality_option)
 
     def show_sample_exif_frame_image(self, file_path, file_name,font_path, exif_padding_option,
-                            text_color, bg_color, ratio_option, alignment_option, caption_format):
+                            text_color, bg_color, ratio_option, alignment_option, caption_format, easymode_option, easymode_oneline):
         
         file_format = Converter.search_file_format(file_path+file_name)
 
@@ -219,7 +222,10 @@ class Converter:
         
         raw_exif_data = image._getexif()
         new_exif_data, image = Converter.fix_orientation(image)
-        full_text = CaptionFormatConverter.convert(caption_format, raw_exif_data)
+        if not easymode_option:
+            full_text = CaptionFormatConverter.convert(caption_format, raw_exif_data)
+        else:
+            full_text = CaptionFormatConverter.convert_easymode(easymode_oneline, raw_exif_data)
 
         if ratio_option == 2:
             image = self.exif.set_45_padding(image, gap = 50, color=background_color)


### PR DESCRIPTION
수정 사항
1. 모든 옵션이 저장되도록 구현 (메인 체크 옵션은 클릭시 바로 저장되고, 팝업 뒤의 옵션은 팝업에서 OK를 눌러야 저장)
2. Resize에 장축, 단축 기준 리사이징 추가
3. 프리뷰 및 워터마크 비활성화 (프리뷰는 버그 및 더 멋진 개선을 위해 잠시 닫아둠)
4. Exif 창 기능 추가: 4:5 지원, 퀄리티 지정 기능, 텍스트 컬러 추가(흰색 텍스트 모드 제거), 텍스트 정렬 기능 추가, 텍스트 자유롭게 쓸 수 있는 기능 추가(한 줄 모드 제거)

Caption 창에서 사용 가능한 wildcard들은 다음과 같으며, 해당되지 않는 것들은 텍스트 그대로 나오므로 원하는 걸 직접 적는 기능도 있음

기존에 있던 것들
* {body} : 바디 정보 (ex:GFX100S)
* {lens} : 렌즈 정보 (ex:GF 80mm f/1.7 R WR)
* {focal_f}: 풀프레임 기준 초점거리 (ex:63mm)
* {aper} : 촬영 조리개 (ex:F/2.8)
* {iso} : 촬영 감도(ex:ISO 100)
* {ss} : 셔터 스피드(ex:1/250s)

새로 추가된 것들
* {mf} : 바디 제조사 (ex:FUJIFILM)
* {lf} : 렌즈 제조사 (ex:FUJIFILM, 서드파티에서 다르게 뜨는지는 확인 안해봄)
* {focal} : 환산 전 초점거리 (ex:80mm)
* {ev} : 노출보정값 (ex:+1.33) // +1 1/3 과 같은 표기는 지원하지 않음
* {meter} : 측광 모드
* {mode} : 촬영 모드 (M, A, S, P 와 기타등등 exif 공식 지원)
* {time} : 촬영 시기 (ex:2023:11:23 19:00:00) // 커스터마이즈를 하고도 싶었으나 국제 표기법 차이 등등 대응 이슈가 있어 그냥 통으로 string을 출력
* {cr} : 저작권 정보
* {ar} : 아티스트 정보