### PR TITLE
Resolve python version checking error with subprocess

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,10 @@
 
 ########################################
 import sys  # 시스템 모듈
-import subprocess
 ########################################
 
 def main():
-    subprocess.run(['python3', '--version'], shell=False)
+    print(sys.version)
     import app_window
     print("App Window module Loaded")
     app = app_window.WebpApp()


### PR DESCRIPTION
3.2.0 버전부터 entry point에서 파이썬 버전 확인을 subprocess로 수행하면서 프로그램이 실행되지 않는 문제 해결
![스크린샷 2024-03-29 214958](https://github.com/C4NU/Paddie/assets/46518263/06210c3a-ac45-4492-ae50-73560671b959)

1. 무슨 이유로 파이썬 버전을 매번 출력하게 만들어놨는진 모르겠지만 이번처럼 오류가 발생할 수 있으니 굳이 없어도 되지 않을까 하는 생각이 드네요
2. 마이너하긴 한데 레포에서 mian 브랜치를 삭제하고 develop/main을 기본으로 바꾸면 좋을거 같아용. clone 해보니까 기본이 main으로 잡혀서 3.1.0 버전이 기본으로 뜨고 따로 브랜치를 바꿔야 최신으로 뜨네요